### PR TITLE
Fix tool change macro conditions

### DIFF
--- a/mmu/base/mmu_macro_vars.cfg
+++ b/mmu/base/mmu_macro_vars.cfg
@@ -484,27 +484,24 @@ variable_user_cancel_extension  : ''		; Executed before the klipper base cancel_
 #
 [gcode_macro T0]
 gcode: 
-    {% if printer.mmu.enabled == 1 and (printer.mmu.tool != 1 or printer.mmu.filament  == "Unloaded") %}
+    {% if printer.mmu.enabled == 1 and not (printer.mmu.filament == "Loaded" and printer.mmu.tool == 0) %}
         MMU_CHANGE_TOOL TOOL=0
     {% endif %}
 
 [gcode_macro T1]
 gcode: 
-    {% if printer.mmu.enabled == 1 and (printer.mmu.tool != 1 or printer.mmu.filament  == "Unloaded") %}
+    {% if printer.mmu.enabled == 1 and not (printer.mmu.filament == "Loaded" and printer.mmu.tool == 1) %}
         MMU_CHANGE_TOOL TOOL=1
     {% endif %}
 
 [gcode_macro T2]
 gcode: 
-    {% if printer.mmu.enabled == 1 and (printer.mmu.tool != 1 or printer.mmu.filament  == "Unloaded") %}
+    {% if printer.mmu.enabled == 1 and not (printer.mmu.filament == "Loaded" and printer.mmu.tool == 2) %}
         MMU_CHANGE_TOOL TOOL=2
     {% endif %}
 
 [gcode_macro T3]
 gcode: 
-    {% if printer.mmu.enabled == 1 and (printer.mmu.tool != 1 or printer.mmu.filament  == "Unloaded") %}
+    {% if printer.mmu.enabled == 1 and not (printer.mmu.filament == "Loaded" and printer.mmu.tool == 3) %}
         MMU_CHANGE_TOOL TOOL=3
     {% endif %}
-
-
-


### PR DESCRIPTION
This pull request updates the logic for tool change macros in the MMU configuration to improve accuracy when deciding whether a tool change is needed. The main change is refining the condition to only trigger a tool change when the requested tool is not already loaded and active.

Macro logic improvements:

* Updated the conditional statements in each tool macro (`T0`, `T1`, `T2`, `T3`) in `mmu/base/mmu_macro_vars.cfg` to check if the requested tool is not already loaded and active, preventing unnecessary tool change commands.