### PR TITLE
Fix eject retraction distance

### DIFF
--- a/mmu/base/mmu_parameters.cfg
+++ b/mmu/base/mmu_parameters.cfg
@@ -130,7 +130,7 @@ gate_unload_buffer: 50			# Amount to reduce the fast unload so that filament doe
 gate_parking_distance: 80 		# Parking position in the gate (distance back from homing point, -ve value means move forward)
 gate_endstop_to_encoder: 10		# Distance between gate endstop and encoder (IF both fitted. +ve if encoder after endstop)
 gate_autoload: 1			# If pre-gate sensor fitted this controls the automatic loading of the gate
-gate_final_eject_distance: 100		# Distance to eject filament on MMU_EJECT (Ignored by MMU_UNLOAD)
+gate_final_eject_distance: 1500		# Distance to eject filament on MMU_EJECT (Ignored by MMU_UNLOAD)
 
 
 # Bowden tube loading/unloading ----------------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request makes a single configuration change to the `mmu/base/mmu_parameters.cfg` file, specifically increasing the distance for ejecting filament during the MMU_EJECT process.

* Increased the value of `gate_final_eject_distance` from 100 to 1500, which will result in a much greater filament ejection distance during the MMU_EJECT operation.