### PR TITLE
Add pressure relief for cutting, retract before cut

### DIFF
--- a/box_hh_macros.cfg
+++ b/box_hh_macros.cfg
@@ -158,13 +158,18 @@ description: Moves to cutter, tensions filament, and cuts.
 gcode:
     {% set T = printer.mmu.tool|default(-1)|int %}
     {% set sv = printer.save_variables.variables %}
+    {% set should_retract = printer.extruder.temperature|float >= 170 %}        
     
     # Check if we should cut (if filament is loaded)
-
     {% if printer.mmu.filament == "Loaded" %}
         RESPOND TYPE=command MSG="Performing filament cut"
 
         BOX_MOVE_TO_CUTTER
+
+        # Perform retraction before cut to reduce filament waste and purge amount
+	    {% if should_retract %}
+	        G1 E-30 F600        
+        {% endif %}
         
         # Tool -1 is unknown, -2 is bypass; don't tension filament with box in these cases
         {% if T >= 0 %}
@@ -173,11 +178,12 @@ gcode:
             {% else %}
                 {% set stepper = ("stepper_mmu_gear_" ~ T) %}
             {% endif %}
-        FORCE_MOVE STEPPER={stepper} DISTANCE=-35 VELOCITY=50 ACCEL=50
-        G4 P500
+       	    FORCE_MOVE STEPPER={stepper} DISTANCE=-35 VELOCITY=50 ACCEL=50
+            G4 P500
         {% endif %}
-
+        
         BOX_DO_CUT
+        FORCE_MOVE STEPPER=extruder DISTANCE=5 VELOCITY=1800 ACCEL=100 # Relieve pressure from cutter
     {% else %}
         RESPOND TYPE=command MSG="Skipping cut - filament not loaded"
     {% endif %}


### PR DESCRIPTION
This pull request introduces improvements to the filament cutting process in the `box_hh_macros.cfg` macro, focusing on reducing filament waste and optimizing the cut procedure. The main changes involve adding a temperature-based retraction before cutting and relieving pressure after cutting.

Enhancements to filament cutting procedure:

* Added a check to perform a 30mm retraction (`G1 E-30 F600`) before cutting if the extruder temperature is at least 170°C, reducing filament waste and purge amount.
* Inserted a `FORCE_MOVE` command to move the extruder forward by 5mm at high speed after cutting, helping to relieve pressure from the cutter.