### PR TITLE
Fix filament sensor pause_on_runout: set to False instead of commenti…

### DIFF
--- a/Max4/README.md
+++ b/Max4/README.md
@@ -78,13 +78,13 @@ sudo service klipper restart
 
 1. Remove Qidi's stock box config `[include box.cfg]` and `[multi_color_controller]`.
 
-2. Modify the `[filament_switch_sensor filament_switch_sensor]` section (HH takes care of runout):
+2. Modify the `[filament_switch_sensor filament_switch_sensor]` section (HH takes care of runout). **Important:** Set `pause_on_runout` to `False` — do not comment it out, as Klipper defaults to `True`:
 ```diff
 +[duplicate_pin_override]
 +pins: THR:PA0
 +
 [filament_switch_sensor filament_switch_sensor]
--pause_on_runout: True
++pause_on_runout: False
 -runout_gcode:
 -            M118 Filament run out
 -            {% set can_auto_reload = printer.save_variables.variables.auto_reload_detect|default(0) %}

--- a/Max4/README.md
+++ b/Max4/README.md
@@ -84,6 +84,7 @@ sudo service klipper restart
 +pins: THR:PA0
 +
 [filament_switch_sensor filament_switch_sensor]
+-pause_on_runout: True
 +pause_on_runout: False
 -runout_gcode:
 -            M118 Filament run out

--- a/Max4/install-bb-max4.sh
+++ b/Max4/install-bb-max4.sh
@@ -251,7 +251,6 @@ def modify_printer_cfg():
     # These properties from the stock filament switch sensor MUST be disabled
     # or they will conflict directly with the MMU operation.
     lines_to_comment = [
-        'pause_on_runout',
         'runout_gcode',
         'M118 Filament run out',
         'can_auto_reload',
@@ -260,7 +259,7 @@ def modify_printer_cfg():
         '{% if',
         'insert_gcode'
     ]
-    
+
     for line in lines:
         if line.strip().startswith('[filament_switch_sensor filament_switch_sensor]'):
             in_sensor = True
@@ -268,17 +267,22 @@ def modify_printer_cfg():
             continue
         elif in_sensor and line.strip().startswith('['):
             in_sensor = False
-            
+
         if in_sensor and line.strip():
             if not line.strip().startswith('#'):
-                should_comment = False
-                for p in lines_to_comment:
-                    if p in line:
-                        should_comment = True
-                        break
-                if should_comment:
-                    line = '# ' + line
-        
+                # Explicitly set pause_on_runout to False instead of commenting it out,
+                # because Klipper defaults to True when the line is commented out.
+                if 'pause_on_runout' in line:
+                    line = 'pause_on_runout: False'
+                else:
+                    should_comment = False
+                    for p in lines_to_comment:
+                        if p in line:
+                            should_comment = True
+                            break
+                    if should_comment:
+                        line = '# ' + line
+
         new_lines.append(line)
 
     with open(printer_cfg_path, 'w') as f:

--- a/Plus4/README.md
+++ b/Plus4/README.md
@@ -77,7 +77,7 @@ sudo service klipper restart
 
 2. Add `[include bunnybox_macros.cfg]` at the top.
 
-3. Modify the `[hall_filament_width_sensor]` section as follows (removing or commenting out the red lines):
+3. Modify the `[hall_filament_width_sensor]` section as follows (removing or commenting out the red lines, and setting `pause_on_runout` to `False`):
 ```diff
 [hall_filament_width_sensor]
 adc1: PA2
@@ -94,7 +94,7 @@ measurement_interval: 10
 logging: False
 -min_diameter: 0.3
 -use_current_dia_while_delay: False
--pause_on_runout:True
++pause_on_runout: False
 -runout_gcode:
 -            RESET_FILAMENT_WIDTH_SENSOR
 -            M118 Filament run out

--- a/Plus4/install-bb-p4.sh
+++ b/Plus4/install-bb-p4.sh
@@ -245,7 +245,6 @@ def modify_printer_cfg():
     lines_to_comment = [
         'min_diameter',
         'use_current_dia_while_delay',
-        'pause_on_runout',
         'runout_gcode',
         'RESET_FILAMENT_WIDTH_SENSOR',
         'M118 Filament run out',
@@ -256,7 +255,7 @@ def modify_printer_cfg():
         'event_delay',
         'pause_delay'
     ]
-    
+
     for line in lines:
         if line.strip().startswith('[hall_filament_width_sensor]'):
             in_hall_sensor = True
@@ -264,17 +263,22 @@ def modify_printer_cfg():
             continue
         elif in_hall_sensor and line.strip().startswith('['):
             in_hall_sensor = False
-            
+
         if in_hall_sensor and line.strip():
             if not line.strip().startswith('#'):
-                should_comment = False
-                for p in lines_to_comment:
-                    if p in line:
-                        should_comment = True
-                        break
-                if should_comment:
-                    line = '# ' + line
-        
+                # Explicitly set pause_on_runout to False instead of commenting it out,
+                # because Klipper defaults to True when the line is commented out.
+                if 'pause_on_runout' in line:
+                    line = 'pause_on_runout: False'
+                else:
+                    should_comment = False
+                    for p in lines_to_comment:
+                        if p in line:
+                            should_comment = True
+                            break
+                    if should_comment:
+                        line = '# ' + line
+
         new_lines.append(line)
 
     with open(printer_cfg_path, 'w') as f:

--- a/Q2/README.md
+++ b/Q2/README.md
@@ -91,6 +91,7 @@ Other mmu directories should not be included!
 +pins: THR:PA1
 +
 [filament_switch_sensor filament_switch_sensor]
+-pause_on_runout: True
 +pause_on_runout: False
 -runout_gcode:
 -            M118 Filament run out

--- a/Q2/README.md
+++ b/Q2/README.md
@@ -85,13 +85,13 @@ sudo service klipper restart
 ```
 Other mmu directories should not be included!
 
-4. Modify the `[filament_switch_sensor filament_switch_sensor]` section (HH takes care of runout):
+4. Modify the `[filament_switch_sensor filament_switch_sensor]` section (HH takes care of runout). **Important:** Set `pause_on_runout` to `False` — do not comment it out, as Klipper defaults to `True`:
 ```diff
 +[duplicate_pin_override]
 +pins: THR:PA1
 +
 [filament_switch_sensor filament_switch_sensor]
--pause_on_runout: True
++pause_on_runout: False
 -runout_gcode:
 -            M118 Filament run out
 -            {% set can_auto_reload = printer.save_variables.variables.auto_reload_detect|default(0) %}

--- a/Q2/install-bb-q2.sh
+++ b/Q2/install-bb-q2.sh
@@ -264,7 +264,6 @@ def modify_printer_cfg():
     # These properties from the stock filament switch sensor MUST be disabled
     # or they will conflict directly with the MMU operation.
     lines_to_comment = [
-        'pause_on_runout',
         'runout_gcode',
         'insert_gcode',
         'M118 Filament run out',
@@ -273,7 +272,7 @@ def modify_printer_cfg():
         '{% endif %}',
         '{% if'
     ]
-    
+
     for line in lines:
         if line.strip().startswith('[filament_switch_sensor filament_switch_sensor]'):
             in_filament_sensor = True
@@ -281,17 +280,22 @@ def modify_printer_cfg():
             continue
         elif in_filament_sensor and line.strip().startswith('['):
             in_filament_sensor = False
-            
+
         if in_filament_sensor and line.strip():
             if not line.strip().startswith('#'):
-                should_comment = False
-                for p in lines_to_comment:
-                    if p in line:
-                        should_comment = True
-                        break
-                if should_comment:
-                    line = '# ' + line
-        
+                # Explicitly set pause_on_runout to False instead of commenting it out,
+                # because Klipper defaults to True when the line is commented out.
+                if 'pause_on_runout' in line:
+                    line = 'pause_on_runout: False'
+                else:
+                    should_comment = False
+                    for p in lines_to_comment:
+                        if p in line:
+                            should_comment = True
+                            break
+                    if should_comment:
+                        line = '# ' + line
+
         new_lines.append(line)
 
     with open(printer_cfg_path, 'w') as f:


### PR DESCRIPTION
…ng out

The install scripts were commenting out pause_on_runout in the filament sensor config sections. Since Klipper defaults pause_on_runout to True when the line is absent, this caused unintended pauses on filament runout that conflict with Happy Hare MMU operation.

Install scripts (Plus4, Q2, Max4) now explicitly set pause_on_runout: False. READMEs updated with correct manual instructions for all three printers.