### PR TITLE
fix: pass z-height in mm to MMU_UPDATE_HEIGHT

### DIFF
--- a/Max4/config_hh-standalone/slicer_machine_gcodes_hh.md
+++ b/Max4/config_hh-standalone/slicer_machine_gcodes_hh.md
@@ -87,7 +87,8 @@ G91
 G1 X1 Z{-initial_layer_print_height-0.1}
 G1 X4
 G1 Z1 F480
-G90```
+G90
+```
 
 # MACHINE END G-CODE
 ```

--- a/Max4/config_hh-standalone/slicer_machine_gcodes_hh.md
+++ b/Max4/config_hh-standalone/slicer_machine_gcodes_hh.md
@@ -133,7 +133,7 @@ G1 Z[layer_z]
 {elsif timelapse_type == 0} ; timelapse without wipe tower
 TIMELAPSE_TAKE_FRAME
 {endif}
-_MMU_UPDATE_HEIGHT HEIGHT={layer_num + 1} 
+_MMU_UPDATE_HEIGHT HEIGHT={layer_z}
 G92 E0
 SET_PRINT_STATS_INFO CURRENT_LAYER={layer_num + 1}
 ```

--- a/Plus4/config_hh-standalone/slicer_machine_gcodes_hh.md
+++ b/Plus4/config_hh-standalone/slicer_machine_gcodes_hh.md
@@ -92,7 +92,7 @@ G1 Y290 F20000
 {elsif timelapse_type == 0} ; timelapse without wipe tower
 TIMELAPSE_TAKE_FRAME
 {endif}
-_MMU_UPDATE_HEIGHT HEIGHT={layer_num + 1} 
+_MMU_UPDATE_HEIGHT HEIGHT={layer_z}
 G92 E0
 SET_PRINT_STATS_INFO CURRENT_LAYER={layer_num + 1}
 ```

--- a/Q2/config_hh-standalone/slicer_machine_gcodes_hh.md
+++ b/Q2/config_hh-standalone/slicer_machine_gcodes_hh.md
@@ -122,7 +122,7 @@ G1 Z[layer_z]
 {elsif timelapse_type == 0} ; timelapse without wipe tower
 TIMELAPSE_TAKE_FRAME
 {endif}
-_MMU_UPDATE_HEIGHT HEIGHT={layer_num + 1} 
+_MMU_UPDATE_HEIGHT HEIGHT={layer_z}
 G92 E0
 SET_PRINT_STATS_INFO CURRENT_LAYER={layer_num + 1}
 ```


### PR DESCRIPTION
[MMU_UPDATE_HEIGHT macro](https://github.com/moggieuk/Happy-Hare/blob/main/config/base/mmu_sequence.cfg#L392]) expects physical Z-height in millimeters so it knows where the floor of the print is when doing the toolchange