### PR TITLE
Bypass isn't enabled by defualt

### DIFF
--- a/Max4/config_hh-standalone/mmu/base/mmu_hardware.cfg
+++ b/Max4/config_hh-standalone/mmu/base/mmu_hardware.cfg
@@ -81,7 +81,7 @@ variable_bowden_lengths: 0		# 1 = If MMU design has different bowden lengths per
 variable_rotation_distances: 0		# 1 = If MMU design has dissimilar drive/BMG gears, thus rotation distance, 0 = One drive gear (e.g. Tradrack)
 require_bowden_move: 1			# 1 = If MMU design has bowden move that is included in load/unload, 0 = zero length bowden (skip bowden move)
 filament_always_gripped: 1		# 1 = Filament is always trapped by MMU (most type-B designs), 0 = MMU can release filament
-has_bypass: 0				# 1 = Bypass gate available, 0 = No filament bypass possible
+has_bypass: 1				# 1 = Bypass gate available, 0 = No filament bypass possible
 
 # Fullname of environment sensor for MMU filament storage (displays temp and humidity in UI). Leave empty if sensor is not fitted
 # Polls for "temperature" and "humidity"

--- a/Plus4/config_hh-standalone/mmu/base/mmu_hardware.cfg
+++ b/Plus4/config_hh-standalone/mmu/base/mmu_hardware.cfg
@@ -81,7 +81,7 @@ variable_bowden_lengths: 0		# 1 = If MMU design has different bowden lengths per
 variable_rotation_distances: 0		# 1 = If MMU design has dissimilar drive/BMG gears, thus rotation distance, 0 = One drive gear (e.g. Tradrack)
 require_bowden_move: 1			# 1 = If MMU design has bowden move that is included in load/unload, 0 = zero length bowden (skip bowden move)
 filament_always_gripped: 1		# 1 = Filament is always trapped by MMU (most type-B designs), 0 = MMU can release filament
-has_bypass: 0				# 1 = Bypass gate available, 0 = No filament bypass possible
+has_bypass: 1				# 1 = Bypass gate available, 0 = No filament bypass possible
 
 # Fullname of environment sensor for MMU filament storage (displays temp and humidity in UI). Leave empty if sensor is not fitted
 # Polls for "temperature" and "humidity"

--- a/Q2/config_hh-standalone/mmu/base/mmu_hardware.cfg
+++ b/Q2/config_hh-standalone/mmu/base/mmu_hardware.cfg
@@ -81,7 +81,7 @@ variable_bowden_lengths: 0		# 1 = If MMU design has different bowden lengths per
 variable_rotation_distances: 0		# 1 = If MMU design has dissimilar drive/BMG gears, thus rotation distance, 0 = One drive gear (e.g. Tradrack)
 require_bowden_move: 1			# 1 = If MMU design has bowden move that is included in load/unload, 0 = zero length bowden (skip bowden move)
 filament_always_gripped: 1		# 1 = Filament is always trapped by MMU (most type-B designs), 0 = MMU can release filament
-has_bypass: 0				# 1 = Bypass gate available, 0 = No filament bypass possible
+has_bypass: 1				# 1 = Bypass gate available, 0 = No filament bypass possible
 
 # Fullname of environment sensor for MMU filament storage (displays temp and humidity in UI). Leave empty if sensor is not fitted
 # Polls for "temperature" and "humidity"


### PR DESCRIPTION
Q2 now has the option that a bypass is possible without the user having to go in and edit it themselves.
The Q2 does have the option to bypass the MMU, specifically with something like M13's [spool holder](https://odysee.com/@The_Mi3_Channel:f/Q2-Flexibles-Top-Spool-Holder:a). This option could also likely be enabled in each of the other machines.