### PR TITLE
Fix link to Q2 gcodes page

### DIFF
--- a/Q2/README.md
+++ b/Q2/README.md
@@ -16,7 +16,7 @@ The easiest way to install Happy Hare on your Qidi Q2 is to use the provided aut
    
 The script will backup your configurations, download the necessary files, prompt you for your serial ID, and automatically install Happy Hare.
 
-Don't forget to update the machine gcodes in the slicer to use the ones provided in the [slicer_machine_gcodes.md](./config_hh-standalone/slicer_machine_gcodes.md).
+Don't forget to update the machine gcodes in the slicer to use the ones provided in the [slicer_machine_gcodes.md](./config_hh-standalone/slicer_machine_gcodes_hh.md).
 
 > [!CAUTION]
 > **The installer does NOT calibrate your MMU.** After installation you MUST calibrate before your first print — see [CALIBRATION — REQUIRED BEFORE FIRST USE](#-calibration--required-before-first-use) at the bottom of this guide. This is the most commonly missed step.


### PR DESCRIPTION
The link URL was missing _hh in it so it goes to a dead page. 